### PR TITLE
Feature/post-processing-fixes

### DIFF
--- a/src/gleasonxai/gleason_data.py
+++ b/src/gleasonxai/gleason_data.py
@@ -410,8 +410,25 @@ class GleasonX(torch.utils.data.Dataset):
         with open(self.path / label_hierarchy_file, "r") as f:
             label_mapping_full = json.load(f)
             label_mapping = label_mapping_full["hierarchy"]
-            # Load German to English translation mapping
-            german_to_english_mapping = label_mapping_full.get("translated", {})
+            
+            # Load and combine all available mappings
+            translated = label_mapping_full.get("translated", {})
+            german_errors = label_mapping_full.get("german_errors", {})
+            english_errors = label_mapping_full.get("english_errors", {})
+            
+            # Create a unified mapping that resolves all steps to the final English translation
+            german_to_english_mapping = translated.copy()
+            
+            # Add German errors, resolving them to English if their correction exists in 'translated'
+            for error, correction in german_errors.items():
+                if correction in translated:
+                    german_to_english_mapping[error] = translated[correction]
+                else:
+                    german_to_english_mapping[error] = correction
+            
+            # Add English errors
+            for error, correction in english_errors.items():
+                german_to_english_mapping[error] = correction
         
         # Load free text mapping
         free_text_mapping_file = "free_text_mapping.json"

--- a/src/gleasonxai/gleason_data.py
+++ b/src/gleasonxai/gleason_data.py
@@ -109,7 +109,7 @@ def load_explanations(path, explanation_file="explanations_df.csv"):
     return df
 
 
-def postprocess_df(df, tma_paths, exp_lvl_remapping, label_level, german_to_english_mapping=None):
+def postprocess_df(df, tma_paths, exp_lvl_remapping, label_level, german_to_english_mapping=None, free_text_mapping=None):
 
     def match_to_tma(tma_identifier):
         return tma_identifier in tma_paths.keys()
@@ -160,6 +160,10 @@ def postprocess_df(df, tma_paths, exp_lvl_remapping, label_level, german_to_engl
 
     assert df["coords"].isnull().sum() == 0, "Some coordinates are null."
 
+    # Apply free text mapping to map free text explanations to standard explanations
+    if free_text_mapping is not None:
+        df["explanations"] = df["explanations"].replace(free_text_mapping)
+    
     # Translate German explanations to English if translation mapping is provided
     if german_to_english_mapping is not None:
         df["explanations"] = df["explanations"].replace(german_to_english_mapping)
@@ -389,6 +393,13 @@ class GleasonX(torch.utils.data.Dataset):
             label_mapping = label_mapping_full["hierarchy"]
             # Load German to English translation mapping
             german_to_english_mapping = label_mapping_full.get("translated", {})
+        
+        # Load free text mapping
+        free_text_mapping_file = "free_text_mapping.json"
+        free_text_mapping = None
+        if (self.path / free_text_mapping_file).exists():
+            with open(self.path / free_text_mapping_file, "r") as f:
+                free_text_mapping = json.load(f)
 
         self.exp_per_level, self.exp_per_level_numbered, self.exp_lvl_remapping, self.exp_numbered_lvl_remapping = parse_label_hierarchy(label_mapping)
 
@@ -409,7 +420,7 @@ class GleasonX(torch.utils.data.Dataset):
             self.background_paths = background_paths
 
         df = load_explanations(path, explanation_file=explanation_file)
-        df = postprocess_df(df, tma_paths, self.exp_lvl_remapping, label_level, german_to_english_mapping)
+        df = postprocess_df(df, tma_paths, self.exp_lvl_remapping, label_level, german_to_english_mapping, free_text_mapping)
 
         self.transforms = transforms
         self.drawing_order = drawing_order

--- a/src/gleasonxai/gleason_data.py
+++ b/src/gleasonxai/gleason_data.py
@@ -169,22 +169,24 @@ def postprocess_df(df, tma_paths, exp_lvl_remapping, label_level, german_to_engl
         first_line = exp.split('\n')[0]
         # Strip "free text:" prefix (case-insensitive)
         cleaned = re.sub(r'(?i)^free text:\s*', '', first_line)
-        # Strip whitespace and trailing dots
-        cleaned = cleaned.strip().rstrip('.')
+        # Normalize internal whitespace
+        cleaned = re.sub(r'\s+', ' ', cleaned)
+        # Strip trailing dots and leading/trailing whitespace
+        cleaned = cleaned.strip(' .')
         return cleaned
 
     df["explanations"] = df["explanations"].apply(clean_explanation)
 
     # Apply free text mapping to map free text explanations to standard explanations
     if free_text_mapping is not None:
-        # Clean mapping keys to match our cleaning logic (lowercase, no trailing dots)
-        cleaned_free_text_mapping = {k.lower().strip().rstrip('.'): v for k, v in free_text_mapping.items()}
+        # Clean mapping keys to match our cleaning logic (lowercase, normalized whitespace, no trailing dots/spaces)
+        cleaned_free_text_mapping = {clean_explanation(k).lower(): v for k, v in free_text_mapping.items()}
         df["explanations"] = df["explanations"].replace(cleaned_free_text_mapping)
     
     # Translate German explanations to English if translation mapping is provided
     if german_to_english_mapping is not None:
         # Clean translation mapping keys to match our cleaning logic
-        cleaned_german_mapping = {k.lower().strip().rstrip('.'): v for k, v in german_to_english_mapping.items()}
+        cleaned_german_mapping = {clean_explanation(k).lower(): v for k, v in german_to_english_mapping.items()}
         df["explanations"] = df["explanations"].replace(cleaned_german_mapping)
 
     # Remap explanations with label hierarchy

--- a/src/gleasonxai/gleason_data.py
+++ b/src/gleasonxai/gleason_data.py
@@ -103,18 +103,49 @@ def load_explanations(path, explanation_file="explanations_df.csv"):
 
     df = pd.read_csv(path / explanation_file)
     df = df.dropna(how="all")
-    df["explanations"] = df["explanations"].astype("category")
+    # Normalize explanations to lowercase to match label_remapping.json format
+    df["explanations"] = df["explanations"].str.lower().astype("category")
 
     return df
 
 
-def postprocess_df(df, tma_paths, exp_lvl_remapping, label_level):
+def postprocess_df(df, tma_paths, exp_lvl_remapping, label_level, german_to_english_mapping=None):
 
     def match_to_tma(tma_identifier):
         return tma_identifier in tma_paths.keys()
 
+    # Create TMA_identifier by stripping file extension from TMA column
+    # The TMA column can have two formats:
+    # 1. Tissue microarray: "PR482a_B2_4.jpeg" where _4 is grade -> "PR482a_B2"
+    # 2. Gleason2019: "slide002_core123_grade3.jpeg" -> "slide002_core123"
+    # The tma_paths keys don't include the grade suffix
+    def extract_tma_info(tma_filename):
+        # Remove file extension to get identifier
+        from pathlib import Path
+        import re
+        identifier = Path(tma_filename).stem
+        # Remove grade suffix patterns:
+        # - Pattern 1: _1 through _5 at the end (tissue microarray)
+        # - Pattern 2: _grade1 through _grade5 at the end (Gleason2019)
+        identifier = re.sub(r'_grade[12345]$', '', identifier)  # Remove _grade[12345]
+        identifier = re.sub(r'_[12345]$', '', identifier)       # Remove _[12345]
+        return identifier
+
+    # OLD CODE which was commented out anyways
     # df[["TMA_identifier", "TMA_path"]] = df["TMA"].apply(
-    #     match_to_tma).apply(pd.Series)
+    #      match_to_tma).apply(pd.Series)
+    
+    df["TMA_identifier"] = df["TMA"].apply(extract_tma_info)
+    
+    # Debug: Check which files cannot be matched
+    unmatched_mask = ~df["TMA_identifier"].apply(match_to_tma)
+    if unmatched_mask.any():
+        unmatched_files = df.loc[unmatched_mask, "TMA_identifier"].unique()
+        print(f"ERROR: {len(unmatched_files)} TMA files could not be matched!")
+        print(f"First 10 unmatched files: {list(unmatched_files[:10])}")
+        print(f"Total TMAs in tma_paths: {len(tma_paths)}")
+        print(f"First 10 TMA keys: {list(tma_paths.keys())[:10]}")
+    
     assert df["TMA_identifier"].apply(match_to_tma).all(), "Some files could not be matched"
 
     # Convert the coordinates of the polygons
@@ -128,6 +159,10 @@ def postprocess_df(df, tma_paths, exp_lvl_remapping, label_level):
     df["coords"] = converted_coords
 
     assert df["coords"].isnull().sum() == 0, "Some coordinates are null."
+
+    # Translate German explanations to English if translation mapping is provided
+    if german_to_english_mapping is not None:
+        df["explanations"] = df["explanations"].replace(german_to_english_mapping)
 
     # Remap explanations with label hierarchy
 
@@ -350,7 +385,10 @@ class GleasonX(torch.utils.data.Dataset):
         except IOError:
             print(f"label hierarchy file {self.path/label_hierarchy_file} does not exist.")
         with open(self.path / label_hierarchy_file, "r") as f:
-            label_mapping = json.load(f)["hierarchy"]
+            label_mapping_full = json.load(f)
+            label_mapping = label_mapping_full["hierarchy"]
+            # Load German to English translation mapping
+            german_to_english_mapping = label_mapping_full.get("translated", {})
 
         self.exp_per_level, self.exp_per_level_numbered, self.exp_lvl_remapping, self.exp_numbered_lvl_remapping = parse_label_hierarchy(label_mapping)
 
@@ -371,7 +409,7 @@ class GleasonX(torch.utils.data.Dataset):
             self.background_paths = background_paths
 
         df = load_explanations(path, explanation_file=explanation_file)
-        df = postprocess_df(df, tma_paths, self.exp_lvl_remapping, label_level)
+        df = postprocess_df(df, tma_paths, self.exp_lvl_remapping, label_level, german_to_english_mapping)
 
         self.transforms = transforms
         self.drawing_order = drawing_order

--- a/src/gleasonxai/gleason_data.py
+++ b/src/gleasonxai/gleason_data.py
@@ -160,16 +160,32 @@ def postprocess_df(df, tma_paths, exp_lvl_remapping, label_level, german_to_engl
 
     assert df["coords"].isnull().sum() == 0, "Some coordinates are null."
 
-    # Strip "free text:" prefix from explanations
-    df["explanations"] = df["explanations"].str.replace(r'^free text:\s*', '', regex=True)
+    # Robust explanation cleaning
+    def clean_explanation(exp):
+        if not isinstance(exp, str):
+            return exp
+        import re
+        # Split by newline and take the first part
+        first_line = exp.split('\n')[0]
+        # Strip "free text:" prefix (case-insensitive)
+        cleaned = re.sub(r'(?i)^free text:\s*', '', first_line)
+        # Strip whitespace and trailing dots
+        cleaned = cleaned.strip().rstrip('.')
+        return cleaned
+
+    df["explanations"] = df["explanations"].apply(clean_explanation)
 
     # Apply free text mapping to map free text explanations to standard explanations
     if free_text_mapping is not None:
-        df["explanations"] = df["explanations"].replace(free_text_mapping)
+        # Clean mapping keys to match our cleaning logic (lowercase, no trailing dots)
+        cleaned_free_text_mapping = {k.lower().strip().rstrip('.'): v for k, v in free_text_mapping.items()}
+        df["explanations"] = df["explanations"].replace(cleaned_free_text_mapping)
     
     # Translate German explanations to English if translation mapping is provided
     if german_to_english_mapping is not None:
-        df["explanations"] = df["explanations"].replace(german_to_english_mapping)
+        # Clean translation mapping keys to match our cleaning logic
+        cleaned_german_mapping = {k.lower().strip().rstrip('.'): v for k, v in german_to_english_mapping.items()}
+        df["explanations"] = df["explanations"].replace(cleaned_german_mapping)
 
     # Remap explanations with label hierarchy
 

--- a/src/gleasonxai/gleason_data.py
+++ b/src/gleasonxai/gleason_data.py
@@ -160,6 +160,9 @@ def postprocess_df(df, tma_paths, exp_lvl_remapping, label_level, german_to_engl
 
     assert df["coords"].isnull().sum() == 0, "Some coordinates are null."
 
+    # Strip "free text:" prefix from explanations
+    df["explanations"] = df["explanations"].str.replace(r'^free text:\s*', '', regex=True)
+
     # Apply free text mapping to map free text explanations to standard explanations
     if free_text_mapping is not None:
         df["explanations"] = df["explanations"].replace(free_text_mapping)


### PR DESCRIPTION
Hi, as I am continuing your research I had to do some changes to the post processing. I was working with the data dir that was already put on the cluster. So, I hope this is universal and not just because of the cluster data. The commits are straight forward, but ill list my changes here:

- tma column stripping to get the exact identifier had to be adjusted to eliminate all Grading prefixes and suffixes --> tma_identifiers stripped and double checked
- the free text mapping wasn't utilised at all --> utilised
- the "free text: " prefix wasn't removed --> now removed
- there still were explanations with 2 parts separated by a "\n" --> now they are separated and the first valid explanation is used
- the German / English errors mappings were not caught --> map them (German error straight to English)
- there were still double spaces in some explanations --> replaced with single spaces

The training runs for me now and the val loss decreases yippie. 